### PR TITLE
fixing the last test

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,17 +1,14 @@
 {
-  // Use IntelliSense to learn about possible attributes.
-  // Hover to view descriptions of existing attributes.
-  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "manifold test",
+      "name": "C/C++: clang++ build and debug active file",
       "type": "cppdbg",
       "request": "launch",
       "program": "${workspaceFolder}/build/test/manifold_test",
       "args": [
         "--gtest_break_on_failure",
-        "--gtest_filter=Manifold.GetMesh"
+        "--gtest_filter=Manifold.NonConvexNonConvexMinkowski"
       ],
       "stopAtEntry": false,
       "cwd": "${workspaceFolder}/build/test",
@@ -20,7 +17,10 @@
           "name": "MALLOC_CHECK_",
           "value": "2"
         }
-      ]
+      ],
+      "externalConsole": false,
+      "MIMode": "lldb",
+      "preLaunchTask": "C/C++: clang++ build active file"
     }
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -136,6 +136,7 @@
     "Gyroid",
     "halfedge",
     "halfedges",
+    "Minkowski",
     "Tris",
     "Verts"
   ],

--- a/src/collider/src/collider.cpp
+++ b/src/collider/src/collider.cpp
@@ -301,6 +301,7 @@ Collider::Collider(const VecView<const Box>& leafBB,
 template <const bool selfCollision, const bool inverted, typename T>
 SparseIndices Collider::Collisions(const VecView<const T>& queriesIn) const {
   ZoneScoped;
+  if (NumInternal() == 0 || queriesIn.size() == 0) return SparseIndices();
   // note that the length is 1 larger than the number of queries so the last
   // element can store the sum when using exclusive scan
   if (queriesIn.size() < kSequentialThreshold) {

--- a/src/manifold/src/manifold.cpp
+++ b/src/manifold/src/manifold.cpp
@@ -830,9 +830,7 @@ Manifold Manifold::Minkowski(const Manifold& other, bool inset) const {
                                b.Translate(aMesh.vertPos[vertexIndices.y]),
                                b.Translate(aMesh.vertPos[vertexIndices.z])});
     }
-    std::vector<Manifold> newHulls;
-    newHulls.reserve(composedParts.size());
-    newHulls.resize(composedParts.size());
+    std::vector<Manifold> newHulls(composedParts.size());
     thrust::for_each_n(
         thrust::host, zip(composedParts.begin(), newHulls.begin()),
         composedParts.size(),

--- a/test/boolean_test.cpp
+++ b/test/boolean_test.cpp
@@ -296,7 +296,7 @@ TEST(Boolean, SplitByPlane60) {
               splits.second.GetProperties().volume, 1e-5);
 }
 
-TEST(Manifold, ConvexConvexMinkowski) {
+TEST(Boolean, ConvexConvexMinkowski) {
   float offsetRadius = 0.1f;
   float cubeWidth = 2.0f;
   Manifold sphere = Manifold::Sphere(offsetRadius, 20);
@@ -311,7 +311,7 @@ TEST(Manifold, ConvexConvexMinkowski) {
   EXPECT_EQ(difference.Genus(), 0);
 }
 
-TEST(Manifold, NonConvexConvexMinkowski) {
+TEST(Boolean, NonConvexConvexMinkowski) {
   Manifold sphere = Manifold::Sphere(1.2, 20);
   Manifold cube = Manifold::Cube({2.0, 2.0, 2.0}, true);
   Manifold nonConvex = cube - sphere;
@@ -327,7 +327,7 @@ TEST(Manifold, NonConvexConvexMinkowski) {
   EXPECT_EQ(difference.Genus(), 5);
 }
 
-TEST(Manifold, NonConvexNonConvexMinkowski) {
+TEST(Boolean, NonConvexNonConvexMinkowski) {
   bool oldDeterministic = ManifoldParams().deterministic;
   ManifoldParams().deterministic = true;
   PolygonParams().processOverlaps = true;
@@ -347,8 +347,7 @@ TEST(Manifold, NonConvexNonConvexMinkowski) {
   EXPECT_EQ(difference.Genus(), 0);
 
 #ifdef MANIFOLD_EXPORT
-  if (options.exportModels)
-    ExportMesh("minkowski.glb", difference.GetMesh(), {});
+  if (options.exportModels) ExportMesh("minkowski.glb", sum.GetMesh(), {});
 #endif
 
   ManifoldParams().deterministic = oldDeterministic;


### PR DESCRIPTION
I made a few minor cleanups here, but the main thing was to simplify the last test. I was getting seg faults, which I tracked down to a one-liner I needed in the collider. Also, the minkowski sum object is clearly correct (a simple fractal):
<img width="663" alt="image" src="https://github.com/zalo/manifold/assets/1649964/97ff639c-9b55-48d3-973a-640726b862f8">
But I'm struggling to find the intuition on what the minkowski difference should look like. Do you think this is correct?
<img width="676" alt="image" src="https://github.com/zalo/manifold/assets/1649964/82f6e974-5861-47a6-8fa4-37112f0eb67d">

Some good news: I realized something about our Booleans that gave me an idea for optimizing our performance when we have these huge internal batches. I did a quick test and found it sped up this NonConvexNonConvex case by 10x! I'll write a separate PR to enable it properly, but not tonight.